### PR TITLE
Correct manifest version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,5 @@
 	"author": "Aidan Gibson",
 	"authorUrl": "https://github.com/aidan-gibson",
 	"isDesktopOnly": true,
-	"version": "1.0.34"
+	"version": "1.0.33"
 }


### PR DESCRIPTION
Wrong version in my previous PR. I thought it would automatically create a new release, but that's not necessary. 

This PR fixed it to the latest version 1.0.33 (instead of one that doesn't exist yet :D))