### PR TITLE
👔 Allow opening duplicates with Cmd-Click

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -275,10 +275,9 @@ export default class Opener extends Plugin {
             }
           }
 
-          // if there's already an empty leaf, pick that one
-          const emptyLeaves = app.workspace.getLeavesOfType('empty');
-          if (emptyLeaves.length > 0) {
-            return oldOpenFile.apply(emptyLeaves[0], [file, openState]);
+          // if an empty leave was already prepared, use that one
+          if (this.getViewState()?.type == 'empty') {
+            return defaultBehavior()
           }
 
           // culmination spear


### PR DESCRIPTION
- **Breaking change: Use prepared tabs**
- Prepared tabs from commands like "Open in new Tab" will now always be used
  - even if the file is already open in another tab
  - if so, a Notice will show up indicating that the file is open twice
- This fixes #33  
- This has arguably pro and cons, I hope though this makes it generally more predictable and stable
- Empty tabs are not recycled anymore (only prepared ones)